### PR TITLE
Add ETag conditional requests for team history endpoint

### DIFF
--- a/backend/app/schemas/team_detail.py
+++ b/backend/app/schemas/team_detail.py
@@ -1,0 +1,37 @@
+"""Schemas for mobile-optimized team detail/history responses."""
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class TransitionInfo(BaseModel):
+    """Represents a lineage transition (predecessor or successor)."""
+    year: int = Field(..., description="Year of the transition event")
+    name: Optional[str] = Field(None, description="Name of the related team")
+    event_type: str = Field(..., description="Classified transition type (MERGED_INTO, ACQUISITION, REVIVAL, SPLIT)")
+
+
+class TeamHistoryEra(BaseModel):
+    """Single era in the team's chronological history."""
+    year: int = Field(..., description="Season year")
+    name: str = Field(..., description="Registered team name")
+    tier: Optional[int] = Field(None, description="UCI tier level (1, 2, 3)")
+    uci_code: Optional[str] = Field(None, description="3-letter UCI code")
+    status: str = Field(..., description="Era status: active, historical, dissolved")
+    predecessor: Optional[TransitionInfo] = Field(None, description="Incoming lineage transition")
+    successor: Optional[TransitionInfo] = Field(None, description="Outgoing lineage transition")
+
+
+class LineageSummary(BaseModel):
+    """High-level lineage flags for quick UI decisions."""
+    has_predecessors: bool = Field(..., description="True if team has any incoming lineage")
+    has_successors: bool = Field(..., description="True if team has any outgoing lineage")
+    spiritual_succession: bool = Field(..., description="True if any spiritual succession events exist")
+
+
+class TeamHistoryResponse(BaseModel):
+    """Mobile-optimized chronological history for a team node."""
+    node_id: str = Field(..., description="UUID of the team node")
+    founding_year: int = Field(..., description="Year the team was founded")
+    dissolution_year: Optional[int] = Field(None, description="Year dissolved, if applicable")
+    timeline: list[TeamHistoryEra] = Field(..., description="Chronological list of eras")
+    lineage_summary: LineageSummary = Field(..., description="Lineage overview")

--- a/backend/app/services/team_detail_service.py
+++ b/backend/app/services/team_detail_service.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.models.team import TeamNode, TeamEra
+from app.models.lineage import LineageEvent
+from app.models.enums import EventType
+from app.schemas.team_detail import (
+    TeamHistoryResponse,
+    TeamHistoryEra,
+    LineageSummary,
+    TransitionInfo,
+)
+
+
+class TeamDetailService:
+    @staticmethod
+    async def get_team_history(session: AsyncSession, node_id: str) -> Optional[TeamHistoryResponse]:
+        stmt = (
+            select(TeamNode)
+            .where(TeamNode.node_id == node_id)
+            .options(
+                selectinload(TeamNode.eras),
+                selectinload(TeamNode.incoming_events)
+                .selectinload(LineageEvent.previous_node)
+                .selectinload(TeamNode.eras),
+                selectinload(TeamNode.outgoing_events)
+                .selectinload(LineageEvent.next_node)
+                .selectinload(TeamNode.eras),
+            )
+        )
+        result = await session.execute(stmt)
+        team: Optional[TeamNode] = result.scalar_one_or_none()
+        if not team:
+            return None
+
+        eras_sorted = sorted(team.eras, key=lambda e: e.season_year)
+        current_year = datetime.utcnow().year
+
+        timeline: List[TeamHistoryEra] = []
+        for era in eras_sorted:
+            status = TeamDetailService.calculate_era_status(
+                era, current_year, team.dissolution_year
+            )
+            predecessor = TeamDetailService._find_predecessor_event(team, era)
+            successor = TeamDetailService._find_successor_event(team, era)
+            timeline.append(
+                TeamHistoryEra(
+                    year=era.season_year,
+                    name=era.registered_name,
+                    tier=era.tier_level,
+                    uci_code=era.uci_code,
+                    status=status,
+                    predecessor=predecessor,
+                    successor=successor,
+                )
+            )
+
+        lineage_summary = LineageSummary(
+            has_predecessors=len(team.incoming_events) > 0,
+            has_successors=len(team.outgoing_events) > 0,
+            spiritual_succession=any(e.event_type == EventType.SPIRITUAL_SUCCESSION for e in team.incoming_events)
+            or any(e.event_type == EventType.SPIRITUAL_SUCCESSION for e in team.outgoing_events),
+        )
+
+        return TeamHistoryResponse(
+            node_id=str(team.node_id),
+            founding_year=team.founding_year,
+            dissolution_year=team.dissolution_year,
+            timeline=timeline,
+            lineage_summary=lineage_summary,
+        )
+
+    @staticmethod
+    def calculate_era_status(
+        era: TeamEra, current_year: int, dissolution_year: Optional[int]
+    ) -> str:
+        if dissolution_year is not None and era.season_year >= dissolution_year:
+            return "dissolved"
+        if era.season_year == current_year and dissolution_year is None:
+            return "active"
+        if era.season_year < current_year:
+            return "historical"
+        return "active"
+
+    @staticmethod
+    def _event_to_transition(event: LineageEvent, name: str) -> TransitionInfo:
+        return TransitionInfo(
+            year=event.event_year,
+            name=name,
+            event_type=TeamDetailService._classify_transition(event),
+        )
+
+    @staticmethod
+    def _classify_transition(event: LineageEvent) -> str:
+        if event.event_type == EventType.MERGE:
+            return "MERGED_INTO"
+        if event.event_type == EventType.SPIRITUAL_SUCCESSION:
+            return "REVIVAL"
+        if event.event_type == EventType.LEGAL_TRANSFER:
+            return "ACQUISITION"
+        if event.event_type == EventType.SPLIT:
+            return "SPLIT"
+        return str(event.event_type)
+
+    @staticmethod
+    def _find_predecessor_event(team: TeamNode, era: TeamEra) -> Optional[TransitionInfo]:
+        # predecessor: incoming event targeting this node with same or previous year
+        candidates = [e for e in team.incoming_events if e.event_year <= era.season_year]
+        if not candidates:
+            return None
+        event = max(candidates, key=lambda e: e.event_year)
+        name = None
+        if event.previous_node and event.previous_node.eras:
+            prev_eras = sorted(event.previous_node.eras, key=lambda x: x.season_year)
+            name = prev_eras[-1].registered_name
+        return TeamDetailService._event_to_transition(event, name or "")
+
+    @staticmethod
+    def _find_successor_event(team: TeamNode, era: TeamEra) -> Optional[TransitionInfo]:
+        # successor: outgoing event from this node after or at era year
+        candidates = [e for e in team.outgoing_events if e.event_year >= era.season_year]
+        if not candidates:
+            return None
+        event = min(candidates, key=lambda e: e.event_year)
+        name = None
+        if event.next_node and event.next_node.eras:
+            next_eras = sorted(event.next_node.eras, key=lambda x: x.season_year)
+            name = next_eras[0].registered_name
+        return TeamDetailService._event_to_transition(event, name or "")

--- a/backend/tests/api/test_team_detail.py
+++ b/backend/tests/api/test_team_detail.py
@@ -1,0 +1,75 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.team import TeamNode, TeamEra
+from app.models.lineage import LineageEvent
+from app.models.enums import EventType
+
+
+@pytest.mark.asyncio
+async def test_team_history_basic(test_client, isolated_session: AsyncSession):
+    # Setup: create node and eras
+    node = TeamNode(founding_year=2010)
+    isolated_session.add(node)
+    await isolated_session.flush()
+    await isolated_session.refresh(node)
+    e2010 = TeamEra(node_id=node.node_id, season_year=2010, registered_name="Team Sky", tier_level=1, uci_code="SKY")
+    e2020 = TeamEra(node_id=node.node_id, season_year=2020, registered_name="Ineos Grenadiers", tier_level=1, uci_code="IGD")
+    isolated_session.add(e2010)
+    isolated_session.add(e2020)
+    await isolated_session.commit()
+
+    resp = await test_client.get(f"/api/v1/teams/{node.node_id}/history")
+    assert resp.status_code == 200
+    assert resp.headers.get("Cache-Control") == "max-age=300"
+    assert resp.headers.get("ETag")
+    data = resp.json()
+    assert data["node_id"] == str(node.node_id)
+    assert len(data["timeline"]) == 2
+    assert data["timeline"][0]["name"] == "Team Sky"
+    assert data["timeline"][1]["name"] == "Ineos Grenadiers"
+
+    # Conditional request with If-None-Match should return 304
+    etag = resp.headers.get("ETag")
+    resp2 = await test_client.get(
+        f"/api/v1/teams/{node.node_id}/history",
+        headers={"If-None-Match": etag},
+    )
+    assert resp2.status_code == 304
+    assert resp2.headers.get("ETag") == etag
+    assert resp2.headers.get("Cache-Control") == "max-age=300"
+
+
+@pytest.mark.asyncio
+async def test_team_history_not_found(test_client):
+    resp = await test_client.get("/api/v1/teams/00000000-0000-0000-0000-000000000000/history")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_team_history_successor_predecessor(test_client, isolated_session: AsyncSession):
+    # Setup nodes
+    prev = TeamNode(founding_year=2000)
+    nextn = TeamNode(founding_year=2021)
+    curr = TeamNode(founding_year=2010)
+    isolated_session.add_all([prev, nextn, curr])
+    await isolated_session.flush()
+    await isolated_session.refresh(prev)
+    await isolated_session.refresh(nextn)
+    await isolated_session.refresh(curr)
+    # eras
+    isolated_session.add(TeamEra(node_id=prev.node_id, season_year=2015, registered_name="OldTeam"))
+    isolated_session.add(TeamEra(node_id=curr.node_id, season_year=2020, registered_name="CurrentTeam"))
+    isolated_session.add(TeamEra(node_id=nextn.node_id, season_year=2021, registered_name="NewTeam"))
+    await isolated_session.flush()
+    # events
+    await isolated_session.merge(LineageEvent(previous_node_id=prev.node_id, next_node_id=curr.node_id, event_year=2016, event_type=EventType.LEGAL_TRANSFER))
+    await isolated_session.merge(LineageEvent(previous_node_id=curr.node_id, next_node_id=nextn.node_id, event_year=2021, event_type=EventType.MERGE))
+    await isolated_session.commit()
+
+    resp = await test_client.get(f"/api/v1/teams/{curr.node_id}/history")
+    assert resp.status_code == 200
+    data = resp.json()
+    era = data["timeline"][0]
+    assert era["predecessor"]["event_type"] == "ACQUISITION"
+    last = data["timeline"][-1]
+    assert last["successor"]["event_type"] == "MERGED_INTO"


### PR DESCRIPTION
## Summary
Implements mobile-optimized team history endpoint with ETag support for bandwidth optimization.

## Changes
- **Endpoint**: GET /api/v1/teams/{node_id}/history
  - Returns chronological timeline with status (ctive, historical, dissolved)
  - Classifies transitions: MERGED_INTO, ACQUISITION, REVIVAL, SPLIT
  - Mobile headers: Cache-Control: max-age=300 and ETag
- **Conditional Requests**: 
  - Supports If-None-Match header
  - Returns 304 Not Modified when client ETag matches current response
  - Preserves headers on 304 response
- **Service**: TeamDetailService with eager loading to avoid async lazy-load issues
- **Tests**: 3 tests covering basic history, not-found, predecessor/successor, and 304 conditional

## Benefits
- Reduces bandwidth for mobile clients
- Improves perceived performance through client-side caching
- Maintains data freshness with 5-minute TTL

## Files
- ackend/app/api/v1/teams.py: Added history endpoint with ETag handling
- ackend/app/schemas/team_detail.py: Response models
- ackend/app/services/team_detail_service.py: Service layer
- ackend/tests/api/test_team_detail.py: Tests

Closes Prompt 9 implementation.