### PR TITLE
Chore: CORS ports + TimelineGraph fix

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,7 +14,12 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Cycling Team Lineage"
     
     # CORS
-    CORS_ORIGINS: List[str] = ["http://localhost:5173"]
+    CORS_ORIGINS: List[str] = [
+        "http://localhost:5173",
+        "http://localhost:5174",
+        "http://127.0.0.1:5173",
+        "http://127.0.0.1:5174",
+    ]
 
     # Timeline cache
     TIMELINE_CACHE_ENABLED: bool = True

--- a/frontend/src/components/TimelineGraph.jsx
+++ b/frontend/src/components/TimelineGraph.jsx
@@ -77,7 +77,6 @@ export default function TimelineGraph({ data }) {
         );
   };
   
-  const renderNodes = (g, nodes) => {
   const renderNodes = (g, nodes, svg) => {
     // Create shadow filter once
     JerseyRenderer.createShadowFilter(svg);


### PR DESCRIPTION
Adds CORS origins for localhost/127.0.0.1 ports 5173/5174 and removes duplicate renderNodes definition causing build error. Needed to allow alternate dev port and resolve frontend connection error.