### PR TITLE
Fix: Upgrade frontend to Node 20 for Vite 7 compatibility

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes frontend container startup failure.

Vite 7.2.4 requires Node.js 20.19+ or 22.12+. The frontend Dockerfile was using node:18-alpine, causing crypto.hash errors.

Changes:
- Updated Dockerfile: node:18-alpine  node:20-alpine

Tested:
- Container now starts successfully
- Frontend loads at http://localhost:5173