### PR TITLE
feat: Implement Moderation Queue (Prompt 26)

### DIFF
--- a/backend/app/api/v1/moderation.py
+++ b/backend/app/api/v1/moderation.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, and_
+from typing import List, Optional
+
+from app.db.database import get_db
+from app.api.dependencies import require_admin
+from app.models.user import User
+from app.models.edit import Edit, EditStatus
+from app.schemas.moderation import (
+    PendingEditResponse,
+    ReviewEditRequest,
+    ReviewEditResponse,
+    ModerationStatsResponse
+)
+from app.services.moderation_service import ModerationService
+
+router = APIRouter(prefix="/api/v1/moderation", tags=["moderation"])
+
+@router.get("/pending", response_model=List[PendingEditResponse])
+async def get_pending_edits(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    edit_type: Optional[str] = None,
+    session: AsyncSession = Depends(get_db),
+    admin: User = Depends(require_admin)
+):
+    """Get list of pending edits for moderation"""
+    stmt = select(Edit).where(Edit.status == EditStatus.PENDING)
+    if edit_type:
+        stmt = stmt.where(Edit.edit_type == edit_type)
+    stmt = stmt.order_by(Edit.created_at.asc()).offset(skip).limit(limit)
+    result = await session.execute(stmt)
+    edits = result.scalars().all()
+    return [await ModerationService.format_edit_for_review(session, edit) for edit in edits]
+
+@router.post("/review/{edit_id}", response_model=ReviewEditResponse)
+async def review_edit(
+    edit_id: str,
+    request: ReviewEditRequest,
+    session: AsyncSession = Depends(get_db),
+    admin: User = Depends(require_admin)
+):
+    """Approve or reject a pending edit"""
+    edit = await session.get(Edit, edit_id)
+    if not edit:
+        raise HTTPException(status_code=404, detail="Edit not found")
+    if edit.status != EditStatus.PENDING:
+        raise HTTPException(status_code=400, detail="Edit is not pending")
+    # Enforce rejection notes in backend
+    if request.approved is False and (not request.notes or not request.notes.strip()):
+        raise HTTPException(status_code=400, detail="Rejection notes are required when rejecting an edit.")
+    result = await ModerationService.review_edit(
+        session,
+        edit,
+        admin,
+        request.approved,
+        request.notes
+    )
+    return result
+
+@router.get("/stats", response_model=ModerationStatsResponse)
+async def get_moderation_stats(
+    session: AsyncSession = Depends(get_db),
+    admin: User = Depends(require_admin)
+):
+    """Get moderation statistics"""
+    return await ModerationService.get_stats(session)

--- a/backend/app/schemas/moderation.py
+++ b/backend/app/schemas/moderation.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+from datetime import datetime
+
+class PendingEditResponse(BaseModel):
+    edit_id: str
+    edit_type: str
+    user_email: str
+    user_display_name: Optional[str]
+    target_info: Dict[str, Any]  # Information about what's being edited
+    changes: Dict[str, Any]
+    reason: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class ReviewEditRequest(BaseModel):
+    approved: bool
+    notes: Optional[str] = None
+
+class ReviewEditResponse(BaseModel):
+    edit_id: str
+    status: str
+    message: str
+
+class ModerationStatsResponse(BaseModel):
+    pending_count: int
+    approved_today: int
+    rejected_today: int
+    pending_by_type: Dict[str, int]

--- a/backend/app/services/moderation_service.py
+++ b/backend/app/services/moderation_service.py
@@ -1,0 +1,193 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func, and_
+from datetime import datetime, timedelta
+from typing import Optional, Dict
+
+from app.models.edit import Edit, EditType, EditStatus
+from app.models.user import User, UserRole
+from app.models.team import TeamEra, TeamNode
+from app.schemas.moderation import (
+    PendingEditResponse,
+    ReviewEditResponse,
+    ModerationStatsResponse
+)
+
+class ModerationService:
+    @staticmethod
+    async def format_edit_for_review(
+        session: AsyncSession,
+        edit: Edit
+    ) -> PendingEditResponse:
+        user = await session.get(User, edit.user_id)
+        target_info = {}
+        if edit.edit_type == EditType.METADATA and edit.target_era_id:
+            era = await session.get(TeamEra, edit.target_era_id)
+            if era:
+                target_info = {
+                    'type': 'era',
+                    'era_id': str(era.era_id),
+                    'team_name': era.registered_name,
+                    'year': era.season_year
+                }
+        elif edit.target_node_id:
+            node = await session.get(TeamNode, edit.target_node_id)
+            if node:
+                target_info = {
+                    'type': 'node',
+                    'node_id': str(node.node_id),
+                    'founding_year': node.founding_year
+                }
+        return PendingEditResponse(
+            edit_id=str(edit.edit_id),
+            edit_type=edit.edit_type.value,
+            user_email=user.email,
+            user_display_name=user.display_name,
+            target_info=target_info,
+            changes=edit.changes,
+            reason=edit.reason,
+            created_at=edit.created_at
+        )
+
+    @staticmethod
+    async def review_edit(
+        session: AsyncSession,
+        edit: Edit,
+        admin: User,
+        approved: bool,
+        notes: Optional[str] = None
+    ) -> ReviewEditResponse:
+        import logging
+        logger = logging.getLogger("moderation")
+        if approved:
+            edit.status = EditStatus.APPROVED
+            edit.reviewed_by = admin.user_id
+            edit.reviewed_at = datetime.utcnow()
+            edit.review_notes = notes
+            try:
+                if edit.edit_type == EditType.METADATA:
+                    await ModerationService._apply_metadata_edit(session, edit)
+                elif edit.edit_type == EditType.MERGE:
+                    await ModerationService._apply_merge_edit(session, edit)
+                elif edit.edit_type == EditType.SPLIT:
+                    await ModerationService._apply_split_edit(session, edit)
+                user = await session.get(User, edit.user_id)
+                user.approved_edits_count += 1
+                logger.info(f"Edit {edit.edit_id} approved by admin {admin.user_id}. User {user.user_id} now has {user.approved_edits_count} approvals.")
+                if user.role == UserRole.NEW_USER and user.approved_edits_count >= 5:
+                    user.role = UserRole.TRUSTED_USER
+                    logger.info(f"User {user.user_id} promoted to Trusted User after {user.approved_edits_count} approvals.")
+                    message = "Edit approved and user promoted to Trusted User"
+                else:
+                    message = "Edit approved and applied"
+            except Exception as e:
+                await session.rollback()
+                logger.error(f"Failed to apply edit {edit.edit_id}: {str(e)}", exc_info=True)
+                raise ValueError(f"Failed to apply edit: {str(e)}")
+        else:
+            edit.status = EditStatus.REJECTED
+            edit.reviewed_by = admin.user_id
+            edit.reviewed_at = datetime.utcnow()
+            edit.review_notes = notes or "Edit rejected by moderator"
+            logger.info(f"Edit {edit.edit_id} rejected by admin {admin.user_id}. Reason: {edit.review_notes}")
+            message = "Edit rejected"
+        await session.commit()
+        return ReviewEditResponse(
+            edit_id=str(edit.edit_id),
+            status=edit.status.value,
+            message=message
+        )
+
+    @staticmethod
+    async def _apply_metadata_edit(session: AsyncSession, edit: Edit):
+        era = await session.get(TeamEra, edit.target_era_id)
+        if not era:
+            raise ValueError("Target era not found")
+        changes = edit.changes
+        if 'registered_name' in changes:
+            era.registered_name = changes['registered_name']
+        if 'uci_code' in changes:
+            era.uci_code = changes['uci_code']
+        if 'tier_level' in changes:
+            era.tier_level = changes['tier_level']
+        era.is_manual_override = True
+        era.source_origin = f"user_{edit.user_id}"
+        era.updated_at = datetime.utcnow()
+        await session.commit()
+        # Logging for metadata edit application
+        import logging
+        logger = logging.getLogger("moderation")
+        logger.info(f"Metadata edit {edit.edit_id} applied to era {era.era_id} by user {edit.user_id}")
+
+    @staticmethod
+    async def _apply_merge_edit(session: AsyncSession, edit: Edit):
+        from app.services.edit_service import EditService
+        from app.schemas.edits import MergeEventRequest
+        changes = edit.changes
+        request = MergeEventRequest(
+            source_node_ids=changes['source_node_ids'],
+            merge_year=changes['merge_year'],
+            new_team_name=changes['new_team_name'],
+            new_team_tier=changes['new_team_tier'],
+            reason=edit.reason
+        )
+        user = await session.get(User, edit.user_id)
+        await EditService._apply_merge(session, request, user)
+
+    @staticmethod
+    async def _apply_split_edit(session: AsyncSession, edit: Edit):
+        from app.services.edit_service import EditService
+        from app.schemas.edits import SplitEventRequest, NewTeamInfo
+        changes = edit.changes
+        request = SplitEventRequest(
+            source_node_id=str(edit.target_node_id),
+            split_year=changes['split_year'],
+            new_teams=[
+                NewTeamInfo(name=team['name'], tier=team['tier'])
+                for team in changes['new_teams']
+            ],
+            reason=edit.reason
+        )
+        user = await session.get(User, edit.user_id)
+        await EditService._apply_split(session, request, user)
+
+    @staticmethod
+    async def get_stats(session: AsyncSession) -> ModerationStatsResponse:
+        pending_stmt = select(func.count(Edit.edit_id)).where(
+            Edit.status == EditStatus.PENDING
+        )
+        pending_result = await session.execute(pending_stmt)
+        pending_count = pending_result.scalar()
+        today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        approved_today_stmt = select(func.count(Edit.edit_id)).where(
+            and_(
+                Edit.status == EditStatus.APPROVED,
+                Edit.reviewed_at >= today_start
+            )
+        )
+        approved_result = await session.execute(approved_today_stmt)
+        approved_today = approved_result.scalar()
+        rejected_today_stmt = select(func.count(Edit.edit_id)).where(
+            and_(
+                Edit.status == EditStatus.REJECTED,
+                Edit.reviewed_at >= today_start
+            )
+        )
+        rejected_result = await session.execute(rejected_today_stmt)
+        rejected_today = rejected_result.scalar()
+        pending_by_type_stmt = select(
+            Edit.edit_type,
+            func.count(Edit.edit_id)
+        ).where(
+            Edit.status == EditStatus.PENDING
+        ).group_by(Edit.edit_type)
+        type_result = await session.execute(pending_by_type_stmt)
+        pending_by_type = {
+            edit_type.value: count
+            for edit_type, count in type_result.all()
+        }
+        return ModerationStatsResponse(
+            pending_count=pending_count,
+            approved_today=approved_today,
+            rejected_today=rejected_today,
+            pending_by_type=pending_by_type
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -123,6 +123,8 @@ app.include_router(teams_router)
 app.include_router(timeline_router)
 app.include_router(admin_router)
 app.include_router(edits_router)
+from app.api.v1 import moderation
+app.include_router(moderation.router)
 
 
 @app.get("/")

--- a/create_test_edit.py
+++ b/create_test_edit.py
@@ -1,0 +1,89 @@
+"""
+Quick script to create test edits via API for testing the moderation queue.
+This simulates what the frontend wizards would do.
+"""
+
+import requests
+import sys
+
+API_BASE = "http://localhost:8000"
+
+def get_token():
+    """Get JWT token - you'll need to login first via the web UI."""
+    print("⚠️  You need to get your access token from the browser:")
+    print("   1. Login to http://localhost:5173")
+    print("   2. Open browser DevTools (F12) → Console")
+    print("   3. Type: localStorage.getItem('accessToken')")
+    print("   4. Copy the token (without quotes)\n")
+    return input("Paste your access token here: ").strip()
+
+def create_metadata_edit(token, era_id, changes, reason):
+    """Create a metadata edit."""
+    headers = {"Authorization": f"Bearer {token}"}
+    data = {
+        "era_id": era_id,
+        "changes": changes,
+        "reason": reason
+    }
+    
+    response = requests.post(
+        f"{API_BASE}/api/v1/edits/metadata",
+        json=data,
+        headers=headers
+    )
+    
+    if response.status_code == 200:
+        result = response.json()
+        print(f"✅ Edit created successfully!")
+        print(f"   Edit ID: {result['edit_id']}")
+        print(f"   Status: {result['status']}")
+        if result['status'] == 'PENDING':
+            print(f"   📋 Edit is pending moderation")
+        else:
+            print(f"   ✨ Edit was auto-approved (trusted user)")
+        return result
+    else:
+        print(f"❌ Failed to create edit: {response.status_code}")
+        print(f"   {response.text}")
+        return None
+
+def main():
+    print("=" * 60)
+    print("🛠️  Create Test Edit for Moderation Queue")
+    print("=" * 60)
+    print()
+    
+    # Get token
+    token = get_token()
+    print()
+    
+    # Get era_id (you can get this from the database or use a known one)
+    print("Enter the era_id to edit (or press Enter for default):")
+    era_id = input("era_id: ").strip()
+    if not era_id:
+        era_id = "cb0be3a8-3b66-45a8-b72e-eceea5ec8f26"  # From our test data
+        print(f"Using default: {era_id}")
+    print()
+    
+    # Example edit
+    print("Creating a test metadata edit...")
+    changes = {
+        "registered_name": "Test Team Name Change",
+        "tier_level": 1
+    }
+    reason = "Testing the moderation queue feature"
+    
+    result = create_metadata_edit(token, era_id, changes, reason)
+    
+    if result:
+        print()
+        print("=" * 60)
+        print("✅ Done! Now go to http://localhost:5173/moderation")
+        print("=" * 60)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n\n❌ Cancelled by user")
+        sys.exit(1)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -129,7 +129,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -479,7 +478,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -523,7 +521,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1526,7 +1523,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1593,7 +1591,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1605,7 +1602,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1717,7 +1713,6 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -1814,6 +1809,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1921,7 +1917,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2422,7 +2417,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2602,7 +2596,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3189,7 +3184,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -3314,6 +3308,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3609,7 +3604,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3671,6 +3665,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3722,7 +3717,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3735,7 +3729,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3749,7 +3742,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4246,7 +4240,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4835,7 +4828,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import HomePage from './pages/HomePage';
 import TeamDetailPage from './pages/TeamDetailPage';
 import LoginPage from './pages/LoginPage';
 import NotFoundPage from './pages/NotFoundPage';
+import ModerationQueuePage from './pages/ModerationQueuePage';
 import { ErrorBoundary } from './components/ErrorDisplay';
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
             <Route index element={<HomePage />} />
             <Route path="team/:nodeId" element={<TeamDetailPage />} />
             <Route path="login" element={<LoginPage />} />
+            <Route path="moderation" element={<ModerationQueuePage />} />
             <Route path="*" element={<NotFoundPage />} />
           </Route>
         </Routes>

--- a/frontend/src/api/moderation.js
+++ b/frontend/src/api/moderation.js
@@ -1,0 +1,12 @@
+import apiClient from './client';
+
+export const moderationApi = {
+  getPendingEdits: (params) =>
+    apiClient.get('/api/v1/moderation/pending', { params }),
+
+  reviewEdit: (editId, data) =>
+    apiClient.post(`/api/v1/moderation/review/${editId}`, data),
+
+  getStats: () =>
+    apiClient.get('/api/v1/moderation/stats'),
+};

--- a/frontend/src/pages/ModerationQueuePage.css
+++ b/frontend/src/pages/ModerationQueuePage.css
@@ -1,0 +1,381 @@
+.moderation-page {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.moderation-header {
+  margin-bottom: 30px;
+}
+
+.moderation-header h1 {
+  font-size: 28px;
+  margin: 0 0 20px 0;
+  color: #333;
+}
+
+.stats-bar {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px 20px;
+  background: #f5f5f5;
+  border-radius: 8px;
+  min-width: 120px;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: #999;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.stat-value {
+  font-size: 24px;
+  font-weight: bold;
+  color: #333;
+}
+
+.stat-value.approved {
+  color: #4CAF50;
+}
+
+.stat-value.rejected {
+  color: #f44336;
+}
+
+.filter-bar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.filter-bar button {
+  padding: 10px 16px;
+  border: 2px solid #ddd;
+  background: white;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.filter-bar button:hover {
+  border-color: #4A90E2;
+}
+
+.filter-bar button.active {
+  background: #4A90E2;
+  color: white;
+  border-color: #4A90E2;
+}
+
+.edits-list {
+  display: grid;
+  gap: 15px;
+}
+
+.edit-card {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.edit-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-color: #4A90E2;
+}
+
+.edit-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.edit-type {
+  display: inline-block;
+  background: #4A90E2;
+  color: white;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.edit-date {
+  font-size: 12px;
+  color: #999;
+}
+
+.edit-user {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 8px;
+}
+
+.edit-target {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.edit-reason {
+  font-size: 13px;
+  color: #777;
+  line-height: 1.4;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: #999;
+}
+
+.empty-state p {
+  font-size: 18px;
+  margin: 0;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  border-bottom: 1px solid #eee;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 20px;
+  color: #333;
+}
+
+.modal-header button {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #999;
+}
+
+.modal-header button:hover {
+  color: #333;
+}
+
+.modal-body {
+  padding: 20px;
+}
+
+.review-section {
+  margin-bottom: 20px;
+}
+
+.review-section h3 {
+  font-size: 14px;
+  color: #999;
+  text-transform: uppercase;
+  margin: 0 0 10px 0;
+}
+
+.review-section p {
+  margin: 0 0 8px 0;
+  color: #333;
+  font-size: 14px;
+}
+
+.review-section .date {
+  font-size: 12px;
+  color: #999;
+}
+
+.review-section pre {
+  background: #f5f5f5;
+  padding: 12px;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: 12px;
+  margin: 0;
+}
+
+.edit-type-badge {
+  display: inline-block;
+  background: #4A90E2;
+  color: white;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.modal-body textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 14px;
+  resize: vertical;
+}
+
+.modal-footer {
+  padding: 20px;
+  border-top: 1px solid #eee;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.modal-footer button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.reject-button {
+  background: #f44336;
+  color: white;
+}
+
+.reject-button:hover:not(:disabled) {
+  background: #d32f2f;
+}
+
+.reject-button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.approve-button {
+  background: #4CAF50;
+  color: white;
+}
+
+.approve-button:hover:not(:disabled) {
+  background: #45a049;
+}
+
+.approve-button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+/* Loading & Error */
+.loading-spinner {
+  text-align: center;
+  padding: 40px;
+  font-size: 16px;
+  color: #666;
+}
+
+.error-display {
+  background: #ffebee;
+  border: 1px solid #f44336;
+  border-radius: 4px;
+  padding: 15px;
+  margin-bottom: 20px;
+  color: #c62828;
+  font-size: 14px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #323232;
+  color: white;
+  padding: 16px 24px;
+  border-radius: 4px;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  animation: slideIn 0.3s ease;
+}
+
+.toast button {
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  font-size: 20px;
+  padding: 0;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(400px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .moderation-page {
+    padding: 15px;
+  }
+
+  .stats-bar {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .stat {
+    flex: 1;
+    min-width: 100px;
+  }
+
+  .modal-content {
+    width: 95%;
+  }
+
+  .filter-bar {
+    flex-direction: column;
+  }
+
+  .filter-bar button {
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/ModerationQueuePage.jsx
+++ b/frontend/src/pages/ModerationQueuePage.jsx
@@ -1,0 +1,235 @@
+import { useState, useEffect, useRef } from 'react';
+import { moderationApi } from '../api/moderation';
+import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import './ModerationQueuePage.css';
+
+function LoadingSpinner() {
+  return <div className="loading-spinner">Loading...</div>;
+}
+
+function Toast({ message, onClose }) {
+  useEffect(() => {
+    if (message) {
+      const timer = setTimeout(onClose, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [message, onClose]);
+  if (!message) return null;
+  return (
+    <div className="toast">
+      {message}
+      <button onClick={onClose} aria-label="Close">×</button>
+    </div>
+  );
+}
+export default function ModerationQueuePage() {
+  const { isAdmin } = useAuth();
+  const navigate = useNavigate();
+  const [edits, setEdits] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('ALL');
+  const [selectedEdit, setSelectedEdit] = useState(null);
+  const [toast, setToast] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isAdmin()) {
+      navigate('/');
+      return;
+    }
+    loadData();
+  }, [filter]);
+
+  const loadData = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [editsResponse, statsResponse] = await Promise.all([
+        moderationApi.getPendingEdits({ edit_type: filter === 'ALL' ? null : filter }),
+        moderationApi.getStats()
+      ]);
+      setEdits(editsResponse.data);
+      setStats(statsResponse.data);
+    } catch (error) {
+      setError('Failed to load moderation data: ' + (error.response?.data?.detail || error.message));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReview = async (editId, approved, notes) => {
+    setError("");
+    try {
+      await moderationApi.reviewEdit(editId, { approved, notes });
+      setEdits(prev => prev.filter(e => e.edit_id !== editId));
+      setSelectedEdit(null);
+      const statsResponse = await moderationApi.getStats();
+      setStats(statsResponse.data);
+      setToast(approved ? 'Edit approved!' : 'Edit rejected!');
+    } catch (error) {
+      setError('Failed to review edit: ' + (error.response?.data?.detail || error.message));
+    }
+  };
+
+  return (
+    <div className="moderation-page">
+      <Toast message={toast} onClose={() => setToast("")} />
+      {loading && <LoadingSpinner />}
+      {error && <div className="error-display">{error}</div>}
+      <div className="moderation-header">
+        <h1>Moderation Queue</h1>
+        {stats && (
+          <div className="stats-bar">
+            <div className="stat">
+              <span className="stat-label">Pending</span>
+              <span className="stat-value">{stats.pending_count}</span>
+            </div>
+            <div className="stat">
+              <span className="stat-label">Approved Today</span>
+              <span className="stat-value approved">{stats.approved_today}</span>
+            </div>
+            <div className="stat">
+              <span className="stat-label">Rejected Today</span>
+              <span className="stat-value rejected">{stats.rejected_today}</span>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="filter-bar">
+        <button className={filter === 'ALL' ? 'active' : ''} onClick={() => setFilter('ALL')}>
+          All ({stats?.pending_count || 0})
+        </button>
+        <button className={filter === 'METADATA' ? 'active' : ''} onClick={() => setFilter('METADATA')}>
+          Metadata ({stats?.pending_by_type?.METADATA || 0})
+        </button>
+        <button className={filter === 'MERGE' ? 'active' : ''} onClick={() => setFilter('MERGE')}>
+          Merges ({stats?.pending_by_type?.MERGE || 0})
+        </button>
+        <button className={filter === 'SPLIT' ? 'active' : ''} onClick={() => setFilter('SPLIT')}>
+          Splits ({stats?.pending_by_type?.SPLIT || 0})
+        </button>
+      </div>
+      <div className="edits-list">
+        {edits.length === 0 && !loading ? (
+          <div className="empty-state">
+            <p>🎉 No pending edits! Queue is clear.</p>
+          </div>
+        ) : (
+          edits.map(edit => (
+            <div key={edit.edit_id} className="edit-card" onClick={() => setSelectedEdit(edit)} tabIndex={0} role="button" aria-pressed="false" onKeyDown={e => {if(e.key==='Enter'){setSelectedEdit(edit);}}}>
+              <div className="edit-header">
+                <span className="edit-type">{edit.edit_type}</span>
+                <span className="edit-date">{new Date(edit.created_at).toLocaleDateString()}</span>
+              </div>
+              <div className="edit-user">By: {edit.user_display_name || edit.user_email}</div>
+              <div className="edit-target">
+                {edit.target_info.team_name && (
+                  <span>{edit.target_info.team_name} ({edit.target_info.year})</span>
+                )}
+              </div>
+              <div className="edit-reason">
+                {edit.reason.substring(0, 100)}
+                {edit.reason.length > 100 && '...'}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+      {selectedEdit && (
+        <EditReviewModal edit={selectedEdit} onClose={() => setSelectedEdit(null)} onReview={handleReview} />
+      )}
+    </div>
+  );
+}
+
+function EditReviewModal({ edit, onClose, onReview }) {
+  const [notes, setNotes] = useState('');
+  const [reviewing, setReviewing] = useState(false);
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, []);
+
+  const handleApprove = async () => {
+    setReviewing(true);
+    await onReview(edit.edit_id, true, notes);
+    setReviewing(false);
+  };
+
+  const handleReject = async () => {
+    if (!notes) {
+      setNotes("");
+      return;
+    }
+    setReviewing(true);
+    await onReview(edit.edit_id, false, notes);
+    setReviewing(false);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content review-modal"
+        onClick={e => e.stopPropagation()}
+        tabIndex={-1}
+        ref={modalRef}
+        onKeyDown={handleKeyDown}
+        aria-modal="true"
+        role="dialog"
+      >
+        <div className="modal-header">
+          <h2>Review Edit</h2>
+          <button onClick={onClose} aria-label="Close">×</button>
+        </div>
+        <div className="modal-body">
+          <div className="review-section">
+            <h3>Edit Type</h3>
+            <p className="edit-type-badge">{edit.edit_type}</p>
+          </div>
+          <div className="review-section">
+            <h3>Submitted By</h3>
+            <p>{edit.user_display_name || edit.user_email}</p>
+            <p className="date">{new Date(edit.created_at).toLocaleString()}</p>
+          </div>
+          <div className="review-section">
+            <h3>Target</h3>
+            <pre>{JSON.stringify(edit.target_info, null, 2)}</pre>
+          </div>
+          <div className="review-section">
+            <h3>Changes</h3>
+            <pre>{JSON.stringify(edit.changes, null, 2)}</pre>
+          </div>
+          <div className="review-section">
+            <h3>Reason</h3>
+            <p>{edit.reason}</p>
+          </div>
+          <div className="review-section">
+            <h3>Review Notes (Optional for approval, required for rejection)</h3>
+            <textarea
+              value={notes}
+              onChange={e => setNotes(e.target.value)}
+              placeholder="Add notes about your decision..."
+              rows={4}
+              aria-label="Review notes"
+            />
+          </div>
+        </div>
+        <div className="modal-footer">
+          <button onClick={handleReject} disabled={reviewing || !notes} className="reject-button">Reject</button>
+          <button onClick={handleApprove} disabled={reviewing} className="approve-button">Approve & Apply</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/setup_test_data.py
+++ b/setup_test_data.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Test data setup script for Velograph moderation queue testing.
+This script:
+1. Creates a test user (NEW_USER role)
+2. Creates pending edits for that user
+3. Optionally sets the logged-in user as ADMIN
+"""
+
+import psycopg2
+from psycopg2.extras import Json
+import uuid
+from datetime import datetime
+import json
+import sys
+
+# Database connection parameters
+DB_HOST = "localhost"
+DB_NAME = "cycling_lineage"
+DB_USER = "cycling"
+DB_PASSWORD = "cycling"
+DB_PORT = 5432
+
+def connect_db():
+    """Connect to PostgreSQL database."""
+    try:
+        conn = psycopg2.connect(
+            host=DB_HOST,
+            database=DB_NAME,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            port=DB_PORT
+        )
+        return conn
+    except Exception as e:
+        print(f"❌ Failed to connect to database: {e}")
+        sys.exit(1)
+
+def setup_test_data(admin_email=None):
+    """Setup test data for moderation testing."""
+    conn = connect_db()
+    cur = conn.cursor()
+    
+    try:
+        print("🚀 Setting up test data for moderation queue...\n")
+        
+        # 1. Create test user (NEW_USER)
+        test_user_id = str(uuid.uuid4())
+        test_email = "testuser@example.com"
+        test_google_id = "test-google-id-" + str(uuid.uuid4())[:8]
+        test_display_name = "Test User"
+        
+        cur.execute("""
+            INSERT INTO users (user_id, google_id, email, display_name, role, approved_edits_count, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, NOW(), NOW())
+            ON CONFLICT (email) DO UPDATE SET role = 'NEW_USER'
+            RETURNING user_id;
+        """, (test_user_id, test_google_id, test_email, test_display_name, "NEW_USER", 0))
+        result = cur.fetchone()
+        test_user_id = result[0]
+        print(f"✅ Created test user: {test_email} (NEW_USER)")
+        print(f"   User ID: {test_user_id}\n")
+        
+        # 2. Get sample era for metadata edit
+        cur.execute("SELECT era_id, registered_name, season_year FROM team_era LIMIT 1;")
+        era_data = cur.fetchone()
+        if not era_data:
+            print("❌ No team eras found in database. Please seed the database first.")
+            return
+        
+        era_id, era_name, era_year = era_data
+        print(f"📋 Using sample era: {era_name} ({era_year})")
+        print(f"   Era ID: {era_id}\n")
+        
+        # 3. Create METADATA edit (pending)
+        metadata_edit_id = str(uuid.uuid4())
+        metadata_changes = {
+            "registered_name": f"{era_name} - UPDATED",
+            "tier_level": 1
+        }
+        
+        cur.execute("""
+            INSERT INTO edits (edit_id, user_id, edit_type, target_era_id, changes, reason, status, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+            ON CONFLICT DO NOTHING;
+        """, (
+            metadata_edit_id,
+            test_user_id,
+            "METADATA",
+            era_id,
+            Json(metadata_changes),
+            "Test: Updated team metadata",
+            "PENDING"
+        ))
+        print(f"✅ Created METADATA edit (PENDING)")
+        print(f"   Edit ID: {metadata_edit_id}")
+        print(f"   Changes: {json.dumps(metadata_changes, indent=2)}\n")
+        
+        # 4. Create another METADATA edit
+        metadata_edit_id_2 = str(uuid.uuid4())
+        metadata_changes_2 = {
+            "uci_code": "TST"
+        }
+        
+        cur.execute("""
+            INSERT INTO edits (edit_id, user_id, edit_type, target_era_id, changes, reason, status, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+            ON CONFLICT DO NOTHING;
+        """, (
+            metadata_edit_id_2,
+            test_user_id,
+            "METADATA",
+            era_id,
+            Json(metadata_changes_2),
+            "Test: Updated UCI code",
+            "PENDING"
+        ))
+        print(f"✅ Created another METADATA edit (PENDING)")
+        print(f"   Edit ID: {metadata_edit_id_2}")
+        print(f"   Changes: {json.dumps(metadata_changes_2, indent=2)}\n")
+        
+        # 5. If admin_email provided, set that user as ADMIN
+        if admin_email:
+            cur.execute("""
+                UPDATE users SET role = 'ADMIN', updated_at = NOW()
+                WHERE email = %s
+                RETURNING user_id, email, role;
+            """, (admin_email,))
+            result = cur.fetchone()
+            if result:
+                print(f"✅ Set {admin_email} as ADMIN")
+                print(f"   User ID: {result[0]}")
+                print(f"   Role: {result[2]}\n")
+            else:
+                print(f"⚠️  User {admin_email} not found in database.")
+                print(f"   Please login first to create the account, then run this script again.\n")
+        
+        # Commit all changes
+        conn.commit()
+        print("✅ All test data committed successfully!\n")
+        
+        # Print summary
+        print("=" * 60)
+        print("📊 TEST SETUP SUMMARY")
+        print("=" * 60)
+        print(f"Test User Email:  {test_email}")
+        print(f"Test User Role:   NEW_USER")
+        print(f"Pending Edits:    2 (both METADATA type)")
+        if admin_email:
+            print(f"Admin User Email: {admin_email}")
+            print(f"Admin User Role: ADMIN")
+        print("\n🎯 Next steps:")
+        print("1. Login as your Google account (you should be ADMIN)")
+        print("2. Navigate to http://localhost:5173/moderation")
+        print("3. You'll see 2 pending edits from 'testuser@example.com'")
+        print("4. Click on an edit to review and approve/reject it")
+        print("=" * 60)
+        
+    except Exception as e:
+        conn.rollback()
+        print(f"❌ Error setting up test data: {e}")
+        sys.exit(1)
+    finally:
+        cur.close()
+        conn.close()
+
+if __name__ == "__main__":
+    admin_email = None
+    if len(sys.argv) > 1:
+        admin_email = sys.argv[1]
+        print(f"ℹ️  Setting admin email: {admin_email}\n")
+    else:
+        print("ℹ️  No admin email provided. Only creating test user and edits.")
+        print("   Usage: python setup_test_data.py <your-google-email>\n")
+    
+    setup_test_data(admin_email)


### PR DESCRIPTION
## Overview
Implements the moderation queue feature allowing admins to review and approve/reject pending edits.

## Changes
### Backend
- Added moderation endpoints (GET /pending, POST /review/{edit_id}, GET /stats)
- Created ModerationService with edit application logic
- Added moderation schemas for API contracts
- Implemented logging and validation for audit trail
- User promotion logic: 5 approved edits  TRUSTED_USER

### Frontend
- Created ModerationQueuePage with stats dashboard
- Implemented edit review modal with approve/reject actions
- Added filtering by edit type (ALL/METADATA/MERGE/SPLIT)
- Created moderation API client
- Added routing for /moderation

## Testing
- All backend tests passing (199 tests)
- All frontend tests passing (76 tests)
- Tested locally with Docker setup

## Related
Implements Prompt 26 from project roadmap.