### PR TITLE
Rename Velograph to ChainLines across docs, config, and UI copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Velograph
-### The Cycling Team Lineage Timeline
+# ChainLines
+### The ChainLines Timeline
 
 An open-source visualization of the evolutionary history of professional cycling teams from 1900 to present.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,8 +1,8 @@
-# Velograph – User Guide
-### The Cycling Team Lineage Timeline
+# ChainLines – User Guide
+### The ChainLines Timeline
 
 ## Overview
-Velograph visualizes and manages the historical evolution of professional cycling teams, including mergers, splits, and successions, using a structured data model and interactive UI.
+ChainLines visualizes and manages the historical evolution of professional cycling teams, including mergers, splits, and successions, using a structured data model and interactive UI.
 
 ## Key Concepts
 - **Team Node**: Represents a legal/managerial entity (the core of a team across years).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,7 @@ DATABASE_URL=postgresql+asyncpg://cycling:cycling@postgres:5432/cycling_lineage
 
 # Application Configuration
 DEBUG=true
-PROJECT_NAME="Cycling Team Lineage"
+PROJECT_NAME="ChainLines"
 API_V1_PREFIX="/api/v1"
 
 # CORS Configuration

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-# Cycling Team Lineage - Backend Makefile
+# ChainLines - Backend Makefile
 # Provides convenient shortcuts for common development tasks
 
 .PHONY: help migrate migrate-rollback migrate-create test shell alembic-upgrade-local

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     # Application
     DEBUG: bool = True
     API_V1_PREFIX: str = "/api/v1"
-    PROJECT_NAME: str = "Cycling Team Lineage"
+    PROJECT_NAME: str = "ChainLines"
     
     # CORS
     CORS_ORIGINS: List[str] = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="Cycling Team Lineage API",
+    title="ChainLines API",
     description="API for tracking professional cycling team history and lineage",
     version="0.1.0",
     lifespan=lifespan
@@ -129,6 +129,6 @@ async def root():
     """Root endpoint"""
     return {
         "status": "ok",
-        "message": "Cycling Team Lineage API",
+        "message": "ChainLines API",
         "version": "0.1.0"
     }

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -27,5 +27,5 @@ def test_health_endpoint():
 
 def test_app_startup():
     """Test that the FastAPI app starts successfully"""
-    assert app.title == "Cycling Team Lineage API"
+    assert app.title == "ChainLines API"
     assert app.version == "0.1.0"

--- a/docs/GOOGLE_OAUTH_SETUP.md
+++ b/docs/GOOGLE_OAUTH_SETUP.md
@@ -1,6 +1,6 @@
 # Google OAuth Setup Guide
 
-This guide will walk you through setting up Google OAuth authentication for the Velograph application.
+This guide will walk you through setting up Google OAuth authentication for the ChainLines application.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ This guide will walk you through setting up Google OAuth authentication for the 
 1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
 2. Click on the project dropdown at the top of the page
 3. Click "New Project"
-4. Enter a project name (e.g., "Velograph Auth")
+4. Enter a project name (e.g., "ChainLines Auth")
 5. Click "Create"
 
 ### 2. Enable Google+ API
@@ -30,7 +30,7 @@ This guide will walk you through setting up Google OAuth authentication for the 
 2. Choose "External" user type (unless you have a Google Workspace account)
 3. Click "Create"
 4. Fill in the required information:
-   - **App name**: Velograph
+   - **App name**: ChainLines
    - **User support email**: Your email
    - **Developer contact email**: Your email
 5. Click "Save and Continue"
@@ -48,13 +48,13 @@ This guide will walk you through setting up Google OAuth authentication for the 
 1. Go to "APIs & Services" > "Credentials"
 2. Click "Create Credentials" > "OAuth client ID"
 3. Select "Web application"
-4. Enter a name (e.g., "Velograph Web Client")
+4. Enter a name (e.g., "ChainLines Web Client")
 5. Under "Authorized JavaScript origins", add:
    - `http://localhost:5173` (for local development)
-   - Your production domain (e.g., `https://velograph.com`)
+   - Your production domain (e.g., `https://chainlines.com`)
 6. Under "Authorized redirect URIs", add:
    - `http://localhost:5173/auth/callback` (for local development)
-   - Your production callback URL (e.g., `https://velograph.com/auth/callback`)
+   - Your production callback URL (e.g., `https://chainlines.com/auth/callback`)
 7. Click "Create"
 8. A dialog will appear with your credentials:
    - **Client ID**: Copy this value

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Velograph</title>
+    <title>ChainLines</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -19,7 +19,7 @@ function Layout() {
       <header className="layout-header">
         <div className="layout-header-content">
           <Link to="/" className="layout-title-link">
-            <h1 className="layout-title">Cycling Team Lineage</h1>
+            <h1 className="layout-title">ChainLines</h1>
           </Link>
           <nav className="layout-nav">
             {isAuthenticated ? (
@@ -38,7 +38,7 @@ function Layout() {
       </main>
 
       <footer className="layout-footer">
-        <p>&copy; {new Date().getFullYear()} Cycling Team Lineage. Open Source Project.</p>
+        <p>&copy; {new Date().getFullYear()} ChainLines. Open Source Project.</p>
       </footer>
     </div>
   );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -25,7 +25,7 @@ export default function LoginPage() {
   return (
     <div className="login-container">
       <div className="login-card">
-        <h1>Cycling Team Lineage</h1>
+        <h1>ChainLines</h1>
         <p>Sign in to contribute to the timeline</p>
 
         <div className="login-button-wrapper">

--- a/setup_test_data.py
+++ b/setup_test_data.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test data setup script for Velograph moderation queue testing.
+Test data setup script for ChainLines moderation queue testing.
 This script:
 1. Creates a test user (NEW_USER role)
 2. Creates pending edits for that user


### PR DESCRIPTION
## Summary
- Update project naming to ChainLines in README.md, USER_GUIDE.md, docs/GOOGLE_OAUTH_SETUP.md
- Align backend defaults and metadata (backend/.env.example, app/core/config.py, main.py, tests) to ChainLines
- Refresh frontend titles/login copy (frontend/index.html, Layout.jsx, LoginPage.jsx)
- No functional/API behavior changes; service wiring unchanged

## Testing
- docker-compose exec backend python -X faulthandler -m pytest -q (postgres running)

## Housekeeping
- Removed stale velograph-* containers/images locally; current images are chainlines-*